### PR TITLE
add ellipse mark (GEN-370)

### DIFF
--- a/notebooks/ellipse.py
+++ b/notebooks/ellipse.py
@@ -1,0 +1,80 @@
+import genstudio.plot as Plot
+
+# Plot ellipses + dots + rects + rules to see how measurements align
+data = [[0, 0], [1, 1], [2, 2]]
+#
+(
+    Plot.ruleX([0, 0.5, 1, 1.5, 2, 2.5], stroke="lightgray")
+    + Plot.ruleY([0, 0.5, 1, 1.5, 2, 2.5], stroke="lightgray")
+    + Plot.dot(data, r=10, fill="black")
+    + Plot.rect(
+        data,
+        {
+            "x1": Plot.js("(d) => d[0] - 0.5"),
+            "x2": Plot.js("(d) => d[0] + 0.5"),
+            "y1": Plot.js("(d) => d[1] - 0.5"),
+            "y2": Plot.js("(d) => d[1] + 0.5"),
+            "fill": "none",
+            "strokeWidth": 4,
+            "stroke": "lightgreen",
+        },
+    )
+    + Plot.ellipse(data, {"fill": "blue"}, r=0.5, opacity=0.5, tip=True)
+)
+
+# Note that the computed domain/extents do not include the radii.
+# AspectRatio=1 ensures a circle.
+data = [
+    {"x": 0, "y": 0, "rx": 0.5, "ry": 0.5, "fill": "blue"},
+    {"x": 2, "y": 2, "rx": 0.5, "ry": 0.5, "fill": "pink"},
+]
+#
+(
+    Plot.ellipse(
+        data,
+        {"x": "x", "y": "y", "rx": "rx", "ry": "ry", "fill": "fill"},
+        opacity=0.5,
+        tip=True,
+    )
+    + Plot.aspect_ratio(1)
+)
+
+# Keep scaled_circle but implement on top of ellipse
+(
+    Plot.scaled_circle(1, 1, 1, fill="red", opacity=0.5, tip=True)
+    + Plot.scaled_circle(1.5, 1.5, 1, fill="blue", opacity=0.5, tip=True)
+    + Plot.domain([0, 2.5])
+    + Plot.aspect_ratio(1)
+)
+
+# Example of ellipses with different rx and ry values
+data_ellipses = [
+    {"x": 1, "y": 1, "rx": 0.8, "ry": 0.3, "fill": "red", "rotate": 0},
+    {"x": 2, "y": 2, "rx": 0.3, "ry": 0.8, "fill": "blue", "rotate": 45},
+    {"x": 3, "y": 1, "rx": 0.5, "ry": 0.5, "fill": "green", "rotate": 90},
+    {"x": 1, "y": 3, "rx": 0.2, "ry": 0.7, "fill": "purple", "rotate": 135},
+]
+#
+(
+    Plot.ellipse(
+        data_ellipses,
+        {
+            "x": "x",
+            "y": "y",
+            "rx": "rx",
+            "ry": "ry",
+            "fill": "fill",
+            "rotate": "rotate",
+        },
+        opacity=0.7,
+        stroke="black",
+        strokeWidth=1,
+        tip=True,
+    )
+    + Plot.ruleX([0, 1, 2, 3, 4], stroke="lightgray")
+    + Plot.ruleY([0, 1, 2, 3, 4], stroke="lightgray")
+    + Plot.dot(data_ellipses, r=3, fill="black")  # Add center points
+    + Plot.domain([0, 4])
+    + Plot.aspect_ratio(1)
+    + Plot.title("Ellipses with Different rx, ry, and rotate values")
+).widget()

--- a/src/genstudio/js/ellipse.js
+++ b/src/genstudio/js/ellipse.js
@@ -1,0 +1,90 @@
+import { Plot, d3 } from "./imports"
+
+import {
+  applyChannelStyles,
+  applyDirectStyles,
+  applyIndirectStyles,
+  applyTransform
+} from "./plot_style";
+
+export const first = (x) => (x ? x[0] : undefined);
+export const second = (x) => (x ? x[1] : undefined);
+export function maybeTuple(x, y) {
+  return x === undefined && y === undefined ? [first, second] : [x, y];
+}
+export function maybeNumberChannel(value, defaultValue) {
+  if (value === undefined) value = defaultValue;
+  return value === null || typeof value === "number" ? [undefined, value] : [value, undefined];
+}
+
+const defaults = {
+  ariaLabel: "ellipse",
+  fill: "currentColor",
+  stroke: "none"
+};
+
+export class Ellipse extends Plot.Mark {
+  constructor(data, options = {}) {
+    let { x, y, rx, ry, r, rotate } = options;
+
+    [x, y] = maybeTuple(x, y)
+    rx = r ?? rx
+    ry = ry ?? rx
+
+    super(data, {
+      x: { value: x, scale: "x" },
+      y: { value: y, scale: "y" },
+      rx: { value: rx },
+      ry: { value: ry },
+      rotate: {value: rotate, optional: true}
+    },
+      options,
+      defaults);
+  }
+
+  render(index, scales, channels, dimensions, context) {
+    let { x: X, y: Y, rx: RX, ry: RY, rotate: ROTATE } = channels;
+
+    return d3.create("svg:g")
+      .call(applyIndirectStyles, this, dimensions, context)
+      .call(applyTransform, this, scales, 0, 0)
+      .call(g => g.selectAll()
+        .data(index)
+        .join("ellipse")
+        .call(applyDirectStyles, this)
+        .attr("cx", i => X[i])
+        .attr("cy", i => Y[i])
+        .attr("rx", i => Math.abs(scales.x(RX[i]) - scales.x(0)))
+        .attr("ry", i => Math.abs(scales.y(RY[i]) - scales.y(0)))
+        .attr("transform", i => ROTATE ? `rotate(${ROTATE[i]}, ${X[i]}, ${Y[i]})` : null)
+        .call(applyChannelStyles, this, channels)
+      )
+      .node();
+  }
+}
+
+/**
+ * Returns a new ellipse mark for the given *data* and *options*.
+ *
+ * If neither **x** nor **y** are specified, *data* is assumed to be an array of
+ * pairs [[*x₀*, *y₀*], [*x₁*, *y₁*], [*x₂*, *y₂*], …] such that **x** = [*x₀*,
+ * *x₁*, *x₂*, …] and **y** = [*y₀*, *y₁*, *y₂*, …].
+ */
+export function ellipse(data, options = {}) {
+  return new Ellipse(data, options);
+}
+
+/**
+ * @typedef {Object} EllipseOptions
+ * @property {ChannelValue} [x] - The x-coordinate of the center of the ellipse.
+ * @property {ChannelValue} [y] - The y-coordinate of the center of the ellipse.
+ * @property {ChannelValue} [rx] - The x-radius of the ellipse.
+ * @property {ChannelValue} [ry] - The y-radius of the ellipse.
+ * @property {ChannelValue} [r] - The radius of the ellipse (used for both rx and ry if specified).
+ * @property {string} [stroke] - The stroke color of the ellipse.
+ * @property {number} [strokeWidth] - The stroke width of the ellipse.
+ * @property {string} [fill] - The fill color of the ellipse.
+ * @property {number} [fillOpacity] - The fill opacity of the ellipse.
+ * @property {number} [strokeOpacity] - The stroke opacity of the ellipse.
+ * @property {string} [title] - The title of the ellipse (tooltip).
+ */

--- a/src/genstudio/js/plot.js
+++ b/src/genstudio/js/plot.js
@@ -1,7 +1,9 @@
 import {Plot, d3, React} from "./imports"
 import { $StateContext, WidthContext, AUTOGRID_MIN } from "./context";
 import { binding, flatten, html } from "./utils";
+import {ellipse} from "./ellipse"
 
+const Marks = {...Plot, ellipse: ellipse}
 const { useEffect } = React
 export const DEFAULT_PLOT_OPTIONS = { inset: 10 };
 
@@ -20,10 +22,10 @@ export class PlotSpec {
 
 export class MarkSpec {
     constructor(name, data, options) {
-        if (!Plot[name]) {
+        if (!Marks[name]) {
             throw new Error(`Plot function "${name}" not found.`);
         }
-        this.fn = Plot[name];
+        this.fn = Marks[name];
 
         options = { ...options }
 

--- a/src/genstudio/js/plot_style.js
+++ b/src/genstudio/js/plot_style.js
@@ -1,0 +1,146 @@
+// internal utils copied from @observablehq/plot/src/style.js
+
+export function applyAttr(selection, name, value) {
+    if (value != null) selection.attr(name, value);
+}
+
+export function applyStyle(selection, name, value) {
+    if (value != null) selection.style(name, value);
+}
+
+export function applyTransform(selection, mark, { x, y }, tx = offset, ty = offset) {
+    tx += mark.dx;
+    ty += mark.dy;
+    if (x?.bandwidth) tx += x.bandwidth() / 2;
+    if (y?.bandwidth) ty += y.bandwidth() / 2;
+    if (tx || ty) selection.attr("transform", `translate(${tx},${ty})`);
+}
+
+export function impliedString(value, impliedValue) {
+    if ((value = string(value)) !== impliedValue) return value;
+}
+
+export function impliedNumber(value, impliedValue) {
+    if ((value = number(value)) !== impliedValue) return value;
+}
+
+function applyHref(selection, href, target) {
+    selection.each(function (i) {
+        const h = href(i);
+        if (h != null) {
+            const a = this.ownerDocument.createElementNS(namespaces.svg, "a");
+            a.setAttribute("fill", "inherit");
+            a.setAttributeNS(namespaces.xlink, "href", h);
+            if (target != null) a.setAttribute("target", target);
+            this.parentNode.insertBefore(a, this).appendChild(this);
+        }
+    });
+}
+
+export function applyTitle(selection, L) {
+    if (L)
+        selection
+            .filter((i) => nonempty(L[i]))
+            .append("title")
+            .call(applyText, L);
+}
+
+export function applyChannelStyles(
+    selection,
+    { target, tip },
+    {
+        ariaLabel: AL,
+        title: T,
+        fill: F,
+        fillOpacity: FO,
+        stroke: S,
+        strokeOpacity: SO,
+        strokeWidth: SW,
+        opacity: O,
+        href: H
+    }
+) {
+    if (AL) applyAttr(selection, "aria-label", (i) => AL[i]);
+    if (F) applyAttr(selection, "fill", (i) => F[i]);
+    if (FO) applyAttr(selection, "fill-opacity", (i) => FO[i]);
+    if (S) applyAttr(selection, "stroke", (i) => S[i]);
+    if (SO) applyAttr(selection, "stroke-opacity", (i) => SO[i]);
+    if (SW) applyAttr(selection, "stroke-width", (i) => SW[i]);
+    if (O) applyAttr(selection, "opacity", (i) => O[i]);
+    if (H) applyHref(selection, (i) => H[i], target);
+    if (!tip) applyTitle(selection, T);
+}
+
+// Note: may mutate selection.node!
+function applyClip(selection, mark, dimensions, context) {
+    let clipUrl;
+    const {clip = context.clip} = mark;
+    switch (clip) {
+      case "frame": {
+        const {width, height, marginLeft, marginRight, marginTop, marginBottom} = dimensions;
+        const id = getClipId();
+        clipUrl = `url(#${id})`;
+        selection = create("svg:g", context)
+          .call((g) =>
+            g
+              .append("svg:clipPath")
+              .attr("id", id)
+              .append("rect")
+              .attr("x", marginLeft)
+              .attr("y", marginTop)
+              .attr("width", width - marginRight - marginLeft)
+              .attr("height", height - marginTop - marginBottom)
+          )
+          .each(function () {
+            this.appendChild(selection.node());
+            selection.node = () => this; // Note: mutation!
+          });
+        break;
+      }
+      case "sphere": {
+        const {projection} = context;
+        if (!projection) throw new Error(`the "sphere" clip option requires a projection`);
+        const id = getClipId();
+        clipUrl = `url(#${id})`;
+        selection
+          .append("clipPath")
+          .attr("id", id)
+          .append("path")
+          .attr("d", geoPath(projection)({type: "Sphere"}));
+        break;
+      }
+    }
+    // Here we’re careful to apply the ARIA attributes to the outer G element when
+    // clipping is applied, and to apply the ARIA attributes before any other
+    // attributes (for readability).
+    applyAttr(selection, "aria-label", mark.ariaLabel);
+    applyAttr(selection, "aria-description", mark.ariaDescription);
+    applyAttr(selection, "aria-hidden", mark.ariaHidden);
+    applyAttr(selection, "clip-path", clipUrl);
+  }
+
+// Note: may mutate selection.node!
+export function applyIndirectStyles(selection, mark, dimensions, context) {
+    applyClip(selection, mark, dimensions, context);
+    applyAttr(selection, "class", mark.className);
+    applyAttr(selection, "fill", mark.fill);
+    applyAttr(selection, "fill-opacity", mark.fillOpacity);
+    applyAttr(selection, "stroke", mark.stroke);
+    applyAttr(selection, "stroke-width", mark.strokeWidth);
+    applyAttr(selection, "stroke-opacity", mark.strokeOpacity);
+    applyAttr(selection, "stroke-linejoin", mark.strokeLinejoin);
+    applyAttr(selection, "stroke-linecap", mark.strokeLinecap);
+    applyAttr(selection, "stroke-miterlimit", mark.strokeMiterlimit);
+    applyAttr(selection, "stroke-dasharray", mark.strokeDasharray);
+    applyAttr(selection, "stroke-dashoffset", mark.strokeDashoffset);
+    applyAttr(selection, "shape-rendering", mark.shapeRendering);
+    applyAttr(selection, "filter", mark.imageFilter);
+    applyAttr(selection, "paint-order", mark.paintOrder);
+    const { pointerEvents = context.pointerSticky === false ? "none" : undefined } = mark;
+    applyAttr(selection, "pointer-events", pointerEvents);
+}
+
+export function applyDirectStyles(selection, mark) {
+    applyStyle(selection, "mix-blend-mode", mark.mixBlendMode);
+    applyAttr(selection, "opacity", mark.opacity);
+}

--- a/src/genstudio/plot.py
+++ b/src/genstudio/plot.py
@@ -7,7 +7,7 @@ import random
 from typing import Any, Dict, List, Union
 
 import genstudio.plot_defs as plot_defs
-from genstudio.js_modules import JSRef, js
+from genstudio.js_modules import JSCall, JSRef, js
 from genstudio.plot_defs import (
     area,
     areaX,
@@ -399,12 +399,14 @@ def test_get_in():
     print("tests passed")
 
 
-def scaled_circle(x, y, r, n=16, curve="catmull-rom-closed", **kwargs):
-    points = [
-        [x + r * math.cos(2 * math.pi * i / n), y + r * math.sin(2 * math.pi * i / n)]
-        for i in range(n)
-    ]
-    return line(points, {"curve": curve, **kwargs})
+def ellipse(values, options: dict[str, Any] = {}, **kwargs) -> PlotSpec:
+    return PlotSpec(
+        JSCall("View", "MarkSpec", ["ellipse", values, {**options, **kwargs}])
+    )
+
+
+def scaled_circle(x, y, r, **kwargs):
+    return ellipse([[x, y]], r=r, **kwargs)
 
 
 def constantly(x):
@@ -484,11 +486,11 @@ def frame(options={}, **kwargs):
     return plot_defs.frame({"stroke": "#dddddd", **options, **kwargs})
 
 
-def ruleY(values, options: Dict[str, Any] = {}, **kwargs):
+def ruleY(values, options: dict[str, Any] = {}, **kwargs):
     return plot_defs.ruleY(values or [0], options, **kwargs)
 
 
-def ruleX(values, options: Dict[str, Any] = {}, **kwargs):
+def ruleX(values, options: dict[str, Any] = {}, **kwargs):
     return plot_defs.ruleX(values or [0], options, **kwargs)
 
 
@@ -671,7 +673,7 @@ def doc(fn):
         return View.md("No docstring available.")
 
 
-def state(name: str) -> Dict[str, str]:
+def state(name: str) -> dict[str, str]:
     return js(f"$state.{name}")
 
 


### PR DESCRIPTION
Adds an ellipse mark which behaves the same as other built-in Plot marks.

More flexible and vastly more efficient than `scaled_circle` (which now defers to ellipse)